### PR TITLE
Make user field in LocationPhotoResult nullable

### DIFF
--- a/lib/src/location_data/location_photos/location_photo_result.dart
+++ b/lib/src/location_data/location_photos/location_photo_result.dart
@@ -17,7 +17,7 @@ class LocationPhotoResult {
   final String publishedDate;
   final Images images;
   final Source source;
-  final PhotosUser user;
+  final PhotosUser? user;
 
   LocationPhotoResult(this.id, this.isBlessed, this.album, this.caption,
       this.publishedDate, this.images, this.source, this.user);

--- a/lib/src/location_data/location_photos/location_photo_result.g.dart
+++ b/lib/src/location_data/location_photos/location_photo_result.g.dart
@@ -15,7 +15,9 @@ LocationPhotoResult _$LocationPhotoResultFromJson(Map json) =>
       json['published_date'] as String,
       Images.fromJson(Map<String, dynamic>.from(json['images'] as Map)),
       Source.fromJson(Map<String, dynamic>.from(json['source'] as Map)),
-      PhotosUser.fromJson(Map<String, dynamic>.from(json['user'] as Map)),
+      json['user'] == null
+          ? null
+          : PhotosUser.fromJson(Map<String, dynamic>.from(json['user'] as Map)),
     );
 
 Map<String, dynamic> _$LocationPhotoResultToJson(
@@ -28,5 +30,5 @@ Map<String, dynamic> _$LocationPhotoResultToJson(
       'published_date': instance.publishedDate,
       'images': instance.images.toJson(),
       'source': instance.source.toJson(),
-      'user': instance.user.toJson(),
+      'user': instance.user?.toJson(),
     };


### PR DESCRIPTION
In order to prevent a crash that occured when a photo query returned without a user